### PR TITLE
uuu.auto: update the version used in the header 1.4.243 -> 1.5.165

### DIFF
--- a/recipes-bsp/tezi-run-metadata/files/apalis-imx8/recovery/uuu.auto
+++ b/recipes-bsp/tezi-run-metadata/files/apalis-imx8/recovery/uuu.auto
@@ -1,4 +1,4 @@
-uuu_version 1.4.243
+uuu_version 1.5.165
 
 SDPS: boot -f ../imx-boot-recoverytezi
 CFG: FB: -vid 0x1b67 -pid 0x4000

--- a/recipes-bsp/tezi-run-metadata/files/colibri-imx6ull/recovery/uuu.auto
+++ b/recipes-bsp/tezi-run-metadata/files/colibri-imx6ull/recovery/uuu.auto
@@ -1,4 +1,4 @@
-uuu_version 1.4.243
+uuu_version 1.5.165
 
 # Boot Rom calls U-Boot over SDP
 SDP: boot -f ../u-boot.imx-recoverytezi

--- a/recipes-bsp/tezi-run-metadata/files/colibri-imx7/recovery/uuu.auto
+++ b/recipes-bsp/tezi-run-metadata/files/colibri-imx7/recovery/uuu.auto
@@ -1,4 +1,4 @@
-uuu_version 1.4.243
+uuu_version 1.5.165
 
 # Boot Rom calls U-Boot over SDP
 SDP: boot -f ../u-boot.imx-recoverytezi

--- a/recipes-bsp/tezi-run-metadata/files/colibri-imx8x/recovery/uuu.auto
+++ b/recipes-bsp/tezi-run-metadata/files/colibri-imx8x/recovery/uuu.auto
@@ -1,4 +1,4 @@
-uuu_version 1.4.243
+uuu_version 1.5.165
 
 SDPS: boot -f ../imx-boot-recoverytezi
 CFG: FB: -vid 0x1b67 -pid 0x4000

--- a/recipes-bsp/tezi-run-metadata/files/k3/recovery/uuu.auto
+++ b/recipes-bsp/tezi-run-metadata/files/k3/recovery/uuu.auto
@@ -1,4 +1,4 @@
-uuu_version 1.4.243
+uuu_version 1.5.165
 
 CFG: FB: -vid 0x1b67 -pid 0x4000
 FB: download -f ../tezi.itb

--- a/recipes-bsp/tezi-run-metadata/files/recovery/uuu.auto
+++ b/recipes-bsp/tezi-run-metadata/files/recovery/uuu.auto
@@ -1,4 +1,4 @@
-uuu_version 1.4.243
+uuu_version 1.5.165
 
 # Boot Rom calls SPL over SDP
 SDP: boot -f ../SPL

--- a/recipes-bsp/tezi-run-metadata/files/verdin-imx8mm/recovery/uuu.auto
+++ b/recipes-bsp/tezi-run-metadata/files/verdin-imx8mm/recovery/uuu.auto
@@ -1,4 +1,4 @@
-uuu_version 1.4.243
+uuu_version 1.5.165
 
 SDP: boot -f ../imx-boot-recoverytezi
 CFG: SDPV: -chip SPL1 -vid 0x1b67 -pid 0x4fff

--- a/recipes-bsp/tezi-run-metadata/files/verdin-imx8mp/recovery/uuu.auto
+++ b/recipes-bsp/tezi-run-metadata/files/verdin-imx8mp/recovery/uuu.auto
@@ -1,4 +1,4 @@
-uuu_version 1.4.243
+uuu_version 1.5.165
 
 SDPS: boot -f ../imx-boot-recoverytezi
 CFG: FB: -vid 0x1b67 -pid 0x4000


### PR DESCRIPTION
uuu binary has been updated to 1.5.165 in meta-freescale scarthgap branch 8 months ago:
https://github.com/Freescale/meta-freescale/commit/bd7974c113c9a231a0c09c5bd649157da32ec027

Adjust the uuu-auto headers to match the current version used.